### PR TITLE
Add force-reorganize feature

### DIFF
--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -49,6 +49,11 @@ def pytest_addoption(parser):
         dest='randomly_reorganize', default=True,
         help="Stop pytest-randomly from randomly reorganizing the test order."
     )
+    group._addoption(
+        '--randomly-force-reorganize', action='store_true',
+        dest='randomly_force_reorganize', default=False,
+        help="Force pytest-randomly to randomly reorganize the test order despite of randomly-seed."
+    )
 
 
 random_states = {}
@@ -102,7 +107,12 @@ def pytest_collection_modifyitems(session, config, items):
     if not config.getoption('randomly_reorganize'):
         return
 
-    _reseed(config)
+    if config.getoption('randomly_force_reorganize'):
+        offset = time.time()
+    else:
+        offset = 0
+
+    _reseed(config, offset)
 
     module_items = []
 

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -108,7 +108,7 @@ def pytest_collection_modifyitems(session, config, items):
         return
 
     if config.getoption('randomly_force_reorganize'):
-        offset = time.time()
+        offset = int(time.time())
     else:
         offset = 0
 

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -505,3 +505,33 @@ def test_faker(testdir):
 
     out = testdir.runpytest('--randomly-seed=1')
     out.assert_outcomes(passed=2)
+
+
+def test_files_reordered_with_force_reorder(testdir):
+    code = """
+        def test_it():
+            pass
+    """
+    testdir.makepyfile(
+        test_a=code,
+        test_b=code,
+        test_c=code,
+        test_d=code,
+    )
+    args = ['-v']
+
+    if six.PY3:  # Python 3 random changes
+        args.append('--randomly-seed=15')
+    else:
+        args.append('--randomly-seed=41')
+
+    # first run
+    out = testdir.runpytest(*args)
+    out.assert_outcomes(passed=4, failed=0)
+
+    # second run with force flag
+    args.append('--randomly-force-reorganize')
+    out2 = testdir.runpytest(*args)
+    out.assert_outcomes(passed=4, failed=0)
+
+    assert out.outlines[8:12] != out2.outlines[8:12]


### PR DESCRIPTION
Sometimes you have to set seed but still want to reorganize tests. Now you can do it with `--randomly-force-reorganize` flag.