### PR TITLE
Upgrade requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mccabe==0.6.1             # via flake8
 modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-numpy==1.15.4
+numpy==1.16.0
 pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -16,6 +16,14 @@ def ourtestdir(testdir):
         '[pytest]\n'
         'console_output_style = classic'
     )
+
+    # Change from default running pytest in-process to running in a subprocess
+    # because numpy imports break with weird:
+    #   File ".../site-packages/numpy/core/overrides.py", line 204, in decorator
+    # add_docstring(implementation, dispatcher.__doc__)
+    # RuntimeError: empty_like method already has a docstring
+    testdir._runpytest_method = testdir.runpytest_subprocess
+
     yield testdir
 
 


### PR DESCRIPTION
Adding workaround for latest version of `numpy` not liking whatever magic Pytest `testdir` does on re-execute.