### PR TITLE
Support for randomly-repeat-last

### DIFF
--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -37,6 +37,10 @@ __version__ = '1.2.3'
 def pytest_addoption(parser):
     group = parser.getgroup('randomly', 'Randomizes tests')
     group._addoption(
+        '--randomly-repeat-last', action='store_true', dest='randomly_repeat_last',
+        help="""Set the seed to the previous run's seed."""
+    )
+    group._addoption(
         '--randomly-seed', action='store', dest='randomly_seed',
         default=int(time.time()), type=int,
         help="""Set the seed that pytest-randomly uses. Default behaviour:
@@ -80,6 +84,15 @@ def _reseed(config, offset=0):
             np_random_states[seed] = np_random.get_state()
         else:
             np_random.set_state(np_random_states[seed])
+
+
+def pytest_configure(config):
+    if config.option.randomly_repeat_last and config.cache.get('last_seed', None):
+        seed = config.cache.get('last_seed', None)
+    else:
+        seed = config.getoption('randomly_seed')
+    config.cache.set('last_seed', seed)
+    config.option.randomly_seed = seed
 
 
 def pytest_report_header(config):

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -69,6 +69,40 @@ def test_it_reuses_the_same_random_seed_per_test(ourtestdir):
     out.assert_outcomes(passed=2, failed=0)
 
 
+def test_it_reuses_the_prev_run_seed(ourtestdir):
+    """
+    Run a test that exercises the randomly-repeat-last option.
+    """
+    ourtestdir.makepyfile(
+        test_one="""
+        def test_a():
+            pass
+        """
+    )
+    out = ourtestdir.runpytest('--randomly-seed=33')
+    out.assert_outcomes(passed=1, failed=0)
+    out.stdout.fnmatch_lines(['Using --randomly-seed=33'])
+    ourtestdir.makepyfile(
+        test_one="""
+        def test_a():
+            pass
+        """
+    )
+    out = ourtestdir.runpytest('--randomly-repeat-last')
+    out.assert_outcomes(passed=1, failed=0)
+    out.stdout.fnmatch_lines(['Using --randomly-seed=33'])
+    ourtestdir.makepyfile(
+        test_one="""
+        def test_a():
+            pass
+        """
+    )
+    out = ourtestdir.runpytest()
+    out.assert_outcomes(passed=1, failed=0)
+    for line in out.outlines:
+        assert 'Using --randomly-seed=33' not in line
+
+
 def test_it_resets_the_random_seed_at_the_start_of_test_classes(ourtestdir):
     ourtestdir.makepyfile(
         test_one="""


### PR DESCRIPTION
This option enables the test to run with the previously used randomly
seed.