### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
-sudo: false
 dist: trusty
 
 notifications:
   email: false
 
 language: python
-python: '3.6'
 cache: pip
 
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.7
+      dist: xenial
+    - python: 3.6
+
 install:
-  - pip install tox
+  - pip install tox-travis
 
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
The CI was only testing 3.6, so add the other supported versions: 2.7, 3.5 and 3.7, but not 3.4 as it'll be EOL on 2019-03-16.

Also `sudo` isn't needed any more (https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) and 3.7 requires Xenial.