### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,9 @@ History
 Pending Release
 ---------------
 
-* New release notes here
+.. Insert new release notes below this line
+
+* Drop Python 2 support, only Python 3.4+ is supported now.
 
 1.2.3 (2017-12-06)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,8 @@ Install from pip with:
 
     pip install pytest-randomly
 
+Python 3.4+ supported.
+
 Pytest will automatically find the plugin and use it when you run ``pytest``.
 The output will start with an extra line that tells you the random seed that is
 being used:

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import random
 import time
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,11 +2,8 @@ docutils
 factory_boy
 faker
 flake8
-futures<3.2.0
 isort
-modernize
 multilint
 numpy
 pygments
 pytest
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,22 +6,15 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 docutils==0.14
-enum34==1.1.6             # via flake8
 factory-boy==2.11.1
 faker==1.0.2
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
-ipaddress==1.0.22         # via faker
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
 numpy==1.16.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -29,6 +22,5 @@ pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest==4.1.1
 python-dateutil==2.7.5    # via faker
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via faker, more-itertools, multilint, pytest, python-dateutil
 text-unidecode==1.2       # via faker

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 120
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,10 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -16,10 +12,10 @@ def get_version(filename):
 version = get_version('pytest_randomly.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 setup(
@@ -36,7 +32,7 @@ setup(
     install_requires=[
         'pytest',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="BSD",
     zip_safe=False,
     keywords='pytest, random, randomize, randomise, randomly',
@@ -49,8 +45,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,13 +1,6 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
-import six
 
-if six.PY3:
-    pytest_plugins = ['pytester']
-else:
-    pytest_plugins = [b'pytester']
+pytest_plugins = ['pytester']
 
 
 @pytest.fixture
@@ -182,11 +175,7 @@ def test_files_reordered(ourtestdir):
         test_c=code,
         test_d=code,
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     out = ourtestdir.runpytest(*args)
 
@@ -210,11 +199,7 @@ def test_files_reordered_when_seed_not_reset(ourtestdir):
         test_c=code,
         test_d=code,
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     args.append('--randomly-dont-reset-seed')
     out = ourtestdir.runpytest(*args)
@@ -254,11 +239,7 @@ def test_classes_reordered(ourtestdir):
                 pass
         """
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     out = ourtestdir.runpytest(*args)
 
@@ -290,11 +271,7 @@ def test_class_test_methods_reordered(ourtestdir):
                 pass
         """
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     out = ourtestdir.runpytest(*args)
 
@@ -323,11 +300,7 @@ def test_test_functions_reordered(ourtestdir):
             pass
         """
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     out = ourtestdir.runpytest(*args)
 
@@ -361,11 +334,7 @@ def test_test_functions_reordered_when_randomness_in_module(ourtestdir):
             pass
         """
     )
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=15')
-    else:
-        args.append('--randomly-seed=41')
+    args = ['-v', '--randomly-seed=15']
 
     out = ourtestdir.runpytest(*args)
 
@@ -396,11 +365,7 @@ def test_doctests_reordered(ourtestdir):
             return 9002
         """
     )
-    args = ['-v', '--doctest-modules']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=5')
-    else:
-        args.append('--randomly-seed=2')
+    args = ['-v', '--doctest-modules', '--randomly-seed=5']
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)
@@ -463,11 +428,7 @@ def test_doctests_in_txt_files_reordered(ourtestdir):
         >>> 2 - 2
         0
         ''')
-    args = ['-v']
-    if six.PY3:  # Python 3 random changes
-        args.append('--randomly-seed=1')
-    else:
-        args.append('--randomly-seed=4')
+    args = ['-v', '--randomly-seed=1']
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,36}-codestyle,
-    py{27,36}
+    py3,
+    py3-codestyle
 
 [testenv]
 setenv =
@@ -10,11 +10,6 @@ install_command = pip install --no-deps {opts} {packages}
 deps = -rrequirements.txt
 commands = pytest -p no:randomly {posargs}
 
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
-
-[testenv:py36-codestyle]
+[testenv:py3-codestyle]
 skip_install = true
 commands = multilint


### PR DESCRIPTION
* Remove coding header
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, update `python_requires`, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove universal wheel building