### PR TITLE
Support Python 3.5 to 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
-sudo: false
-dist: trusty
+dist: xenial
 
 notifications:
   email: false
 
 language: python
-python: '3.6'
 cache: pip
+
+matrix:
+  include:
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
 
 install:
   - pip install tox

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Update Python support to 3.5-3.7, as 3.4 has reached its end of life.
+
 2.1.1 (2019-03-26)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Install from pip with:
 
     pip install pytest-randomly
 
-Python 3.4+ supported.
+Python 3.5-3.7 supported.
 
 Pytest will automatically find the plugin and use it when you run ``pytest``.
 The output will start with an extra line that tells you the random seed that is
@@ -75,8 +75,9 @@ being used:
 .. code-block:: bash
 
     $ pytest
-    platform darwin -- Python 2.7.11, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
-    Using --randomly-seed=1460130750
+    ...
+    platform darwin -- Python 3.7.2, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
+    Using --randomly-seed=1553614239
     ...
 
 If the tests fail due to ordering or randomly created data, you can restart

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ mccabe==0.6.1             # via flake8
 more-itertools==6.0.0     # via pytest
 multilint==2.4.0
 numpy==1.16.2
+pathlib2==2.3.3 ; python_version < '3.6'
 pluggy==0.9.0             # via pytest
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
* Update Travis config to use a matrix.
* Update README to say "Python 3.5-3.7 supported."
* Update classifiers in `setup.py`
* Add note in `HISTORY.rst` "Update Python support to 3.5-3.7, as 3.4 has reached its end of life."