### PR TITLE
Handle failing imports / collection errors

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Pending Release
 .. Insert new release notes below this line
 
 * Update Python support to 3.5-3.7, as 3.4 has reached its end of life.
+* Handle CollectErrors and ImportErrors during collection when accessing
+  ``item.module``.
+
 
 2.1.1 (2019-03-26)
 ------------------

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -2,6 +2,8 @@ import argparse
 import random
 import time
 
+from pytest import Collector
+
 # factory-boy
 try:
     from factory.random import set_random_state as factory_set_random_state
@@ -135,10 +137,14 @@ def pytest_collection_modifyitems(session, config, items):
     current_items = []
     for item in items:
 
-        if current_module is None:
-            current_module = getattr(item, 'module', None)
+        try:
+            item_module = getattr(item, 'module', None)
+        except (ImportError, Collector.CollectError):
+            item_module = None
 
-        item_module = getattr(item, 'module', None)
+        if current_module is None:
+            current_module = item_module
+
         if item_module != current_module:
             module_items.append(shuffle_by_class(current_items))
             current_items = [item]

--- a/test_pytest_randomly.py
+++ b/test_pytest_randomly.py
@@ -602,3 +602,17 @@ def test_numpy(ourtestdir):
 
     out = ourtestdir.runpytest('--randomly-seed=1')
     out.assert_outcomes(passed=2)
+
+
+def test_failing_import(testdir):
+    """Test with pytest raising CollectError or ImportError.
+
+    This happens when trying to access item.module during
+    pytest_collection_modifyitems.
+    """
+    modcol = testdir.getmodulecol("import alksdjalskdjalkjals")
+    assert modcol.instance is None
+
+    modcol = testdir.getmodulecol("pytest_plugins='xasdlkj',")
+    with pytest.raises(ImportError):
+        modcol.obj


### PR DESCRIPTION
The tests are based on existing tests in pytest, which would fail with
pytest-randomly being used for its tests.