### PR TITLE
Add an entry point to register external random engines

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,8 @@ Pending Release
 .. Insert new release notes below this line
 
 * Add plugins via entry points ``pytest_randomly.random_seeder`` to allow
-  outside packages to register additional random generators to seed.
+  outside packages to register additional random generators to seed. This has
+  added a dependency on the ``entrypoints`` package.
 
 3.0.0 (2019-04-05)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,9 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Add plugins via entry points ``pytest_randomly.random_seeder`` to allow
+  outside packages to register additional random generators to seed.
+
 3.0.0 (2019-04-05)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,8 @@ All of these features are on by default but can be disabled with flags.
 * If additional random generators are used, they can be registered under the
   ``pytest_randomly.random_seeder``
   `entry point <https://packaging.python.org/specifications/entry-points/>`_ and
-  will have their seed reset at the start of every test.
+  will have their seed reset at the start of every test. Register a function
+  that takes the current seed value.
 
 About
 -----

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,10 @@ All of these features are on by default but can be disabled with flags.
   data in tests - factory boy uses faker for lots of data.
 * If `numpy <http://www.numpy.org/>`_ is installed, its random state is reset
   at the start of every test.
+* If additional random generators are used, they can be registered under the
+  ``pytest_randomly.random_seeder``
+  `entry point <https://packaging.python.org/specifications/entry-points/>`_ and
+  will have their seed reset at the start of every test.
 
 About
 -----

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -2,6 +2,7 @@ import argparse
 import random
 import time
 
+import pkg_resources
 from pytest import Collector
 
 # factory-boy
@@ -107,6 +108,11 @@ def _reseed(config, offset=0):
             np_random_states[seed] = np_random.get_state()
         else:
             np_random.set_state(np_random_states[seed])
+
+    # Find any dynamically registered entry points
+    for entry_point in pkg_resources.iter_entry_points('pytest_randomly.random_seeder'):
+        plugin_seeder = entry_point.load()
+        plugin_seeder(seed)
 
 
 def pytest_report_header(config):

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -30,8 +30,7 @@ docutils==0.15.2 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
-    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
-    # via flake8
+    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
 factory-boy==2.12.0 \
     --hash=sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee \
     --hash=sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370
@@ -171,4 +170,4 @@ zipp==0.5.2 \
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools==41.1.0        # via twine
+# setuptools==41.2.0        # via twine

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -30,8 +30,7 @@ docutils==0.15.2 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
-    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
-    # via flake8
+    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
 factory-boy==2.12.0 \
     --hash=sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee \
     --hash=sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370
@@ -167,4 +166,4 @@ zipp==0.5.2 \
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools==41.1.0        # via twine
+# setuptools==41.2.0        # via twine

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -41,8 +41,7 @@ docutils==0.15.2 \
     --hash=sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
-    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
-    # via flake8
+    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
 factory-boy==2.12.0 \
     --hash=sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee \
     --hash=sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370
@@ -182,4 +181,4 @@ zipp==0.5.2 \
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.
-# setuptools==41.1.0        # via twine
+# setuptools==41.2.0        # via twine

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,6 @@
 black ; python_version == '3.7.*'
 docutils
+entrypoints
 factory_boy
 faker
 flake8

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(
     },
     py_modules=["pytest_randomly"],
     include_package_data=True,
-    install_requires=["pytest"],
+    install_requires=[
+        "entrypoints",
+        "pytest",
+    ],
     python_requires=">=3.5",
     license="BSD",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,7 @@ setup(
     },
     py_modules=["pytest_randomly"],
     include_package_data=True,
-    install_requires=[
-        "entrypoints",
-        "pytest",
-    ],
+    install_requires=["entrypoints", "pytest"],
     python_requires=">=3.5",
     license="BSD",
     zip_safe=False,

--- a/test_pytest_randomly.py
+++ b/test_pytest_randomly.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 import pytest_randomly
 
 pytest_plugins = ["pytester"]


### PR DESCRIPTION
This adds the entry point `pytest_randomly.random_seeder`. Anything specified under this entry point will be called with the static seed value every time the random generators are reseeded, as though it were one of the `.seed()` functions.

The current method of adding large packages directly is great, but we've got a package that has it's own random generator and isn't nearly big enough to be worth integrating into this package. This patch solves that by allowing any external packages to register an entry point for pytest-randomly. If pytest-randomly isn't installed then the extra entry point is harmless.

This is a single-function interface at the moment so means that you can't re-set the state - it has to be generated from the seed every time. I don't know if there was some reason other than speed that the generators are set from state if possible, rather than seed. If this is a problem, there could be an object API to allow getting/setting state but unless we need the complication I didn't want to go that far in an initial proposal.

Since I'm not sure the canonical way to test `pkg_resources`, I've put a test in that monkeypatches the interface. Depending on your taste/rigour this might not be acceptable.

This would also presumably add an avenue for fixing #135 and any other packages that want similar.