### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ pytest-randomly
 .. image:: https://img.shields.io/pypi/v/pytest-randomly.svg
         :target: https://pypi.python.org/pypi/pytest-randomly
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 .. figure:: https://raw.githubusercontent.com/pytest-dev/pytest-randomly/master/logo.png
    :scale: 50%
    :alt: Randomness power.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py35']

--- a/pytest_randomly.py
+++ b/pytest_randomly.py
@@ -7,11 +7,13 @@ from pytest import Collector
 # factory-boy
 try:
     from factory.random import set_random_state as factory_set_random_state
+
     have_factory_boy = True
 except ImportError:
     # old versions
     try:
         from factory.fuzzy import set_random_state as factory_set_random_state
+
         have_factory_boy = True
     except ImportError:
         have_factory_boy = False
@@ -19,6 +21,7 @@ except ImportError:
 # faker
 try:
     from faker.generator import random as faker_random
+
     have_faker = True
 except ImportError:
     have_faker = False
@@ -26,19 +29,20 @@ except ImportError:
 # numpy
 try:
     from numpy import random as np_random
+
     have_numpy = True
 except ImportError:
     have_numpy = False
 
 
-__version__ = '3.0.0'
+__version__ = "3.0.0"
 
 
 default_seed = int(time.time())
 
 
 def seed_type(string):
-    if string == 'last':
+    if string == "last":
         return string
     try:
         return int(string)
@@ -49,26 +53,33 @@ def seed_type(string):
 
 
 def pytest_addoption(parser):
-    group = parser.getgroup('randomly', 'Randomizes tests')
+    group = parser.getgroup("randomly", "Randomizes tests")
     group._addoption(
-        '--randomly-seed', action='store', dest='randomly_seed',
-        default=str(default_seed), type=seed_type,
+        "--randomly-seed",
+        action="store",
+        dest="randomly_seed",
+        default=str(default_seed),
+        type=seed_type,
         help="""Set the seed that pytest-randomly uses (int), or pass the
                 special value 'last' to reuse the seed from the previous run.
                 Default behaviour: use int(time.time()), so the seed is
-                different on each run."""
+                different on each run.""",
     )
     group._addoption(
-        '--randomly-dont-reset-seed', action='store_false',
-        dest='randomly_reset_seed', default=True,
+        "--randomly-dont-reset-seed",
+        action="store_false",
+        dest="randomly_reset_seed",
+        default=True,
         help="""Stop pytest-randomly from resetting random.seed() at the
                 start of every test context (e.g. TestCase) and individual
-                test."""
+                test.""",
     )
     group._addoption(
-        '--randomly-dont-reorganize', action='store_false',
-        dest='randomly_reorganize', default=True,
-        help="Stop pytest-randomly from randomly reorganizing the test order."
+        "--randomly-dont-reorganize",
+        action="store_false",
+        dest="randomly_reorganize",
+        default=True,
+        help="Stop pytest-randomly from randomly reorganizing the test order.",
     )
 
 
@@ -77,7 +88,7 @@ np_random_states = {}
 
 
 def _reseed(config, offset=0):
-    seed = config.getoption('randomly_seed') + offset
+    seed = config.getoption("randomly_seed") + offset
     if seed not in random_states:
         random.seed(seed)
         random_states[seed] = random.getstate()
@@ -99,34 +110,34 @@ def _reseed(config, offset=0):
 
 
 def pytest_report_header(config):
-    seed_value = config.getoption('randomly_seed')
-    if seed_value == 'last':
-        seed = config.cache.get('randomly_seed', default_seed)
+    seed_value = config.getoption("randomly_seed")
+    if seed_value == "last":
+        seed = config.cache.get("randomly_seed", default_seed)
     else:
         seed = seed_value
-    config.cache.set('randomly_seed', seed)
+    config.cache.set("randomly_seed", seed)
     config.option.randomly_seed = seed
     _reseed(config)
     return "Using --randomly-seed={0}".format(seed)
 
 
 def pytest_runtest_setup(item):
-    if item.config.getoption('randomly_reset_seed'):
+    if item.config.getoption("randomly_reset_seed"):
         _reseed(item.config, -1)
 
 
 def pytest_runtest_call(item):
-    if item.config.getoption('randomly_reset_seed'):
+    if item.config.getoption("randomly_reset_seed"):
         _reseed(item.config)
 
 
 def pytest_runtest_teardown(item):
-    if item.config.getoption('randomly_reset_seed'):
+    if item.config.getoption("randomly_reset_seed"):
         _reseed(item.config, 1)
 
 
 def pytest_collection_modifyitems(session, config, items):
-    if not config.getoption('randomly_reorganize'):
+    if not config.getoption("randomly_reorganize"):
         return
 
     _reseed(config)
@@ -138,7 +149,7 @@ def pytest_collection_modifyitems(session, config, items):
     for item in items:
 
         try:
-            item_module = getattr(item, 'module', None)
+            item_module = getattr(item, "module", None)
         except (ImportError, Collector.CollectError):
             item_module = None
 
@@ -165,9 +176,9 @@ def shuffle_by_class(items):
 
     for item in items:
         if current_cls is None:
-            current_cls = getattr(item, 'cls', None)
+            current_cls = getattr(item, "cls", None)
 
-        if getattr(item, 'cls', None) != current_cls:
+        if getattr(item, "cls", None) != current_cls:
             random.shuffle(current_items)
             class_items.append(current_items)
             current_items = [item]

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -38,6 +38,9 @@ factory-boy==2.12.0 \
 faker==1.0.7 \
     --hash=sha256:1c0a5e7bb54d2c54569986a27124715c83899e592d8d61d4e372dbff6c699573 \
     --hash=sha256:60477f757a80f665bbe1fb3d1cfe5d205ec7b99d5240114de7b27b4c25d236ca
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -38,6 +38,9 @@ factory-boy==2.12.0 \
 faker==1.0.7 \
     --hash=sha256:1c0a5e7bb54d2c54569986a27124715c83899e592d8d61d4e372dbff6c699573 \
     --hash=sha256:60477f757a80f665bbe1fb3d1cfe5d205ec7b99d5240114de7b27b4c25d236ca
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 docutils==0.14 \
     --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
     --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
@@ -38,6 +49,9 @@ factory-boy==2.12.0 \
 faker==1.0.7 \
     --hash=sha256:1c0a5e7bb54d2c54569986a27124715c83899e592d8d61d4e372dbff6c699573 \
     --hash=sha256:60477f757a80f665bbe1fb3d1cfe5d205ec7b99d5240114de7b27b4c25d236ca
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -145,6 +159,10 @@ text-unidecode==1.2 \
     --hash=sha256:5a1375bb2ba7968740508ae38d92e1f889a0832913cb1c447d5e2046061a396d \
     --hash=sha256:801e38bd550b943563660a91de8d4b6fa5df60a542be9093f7abf819f86050cc \
     # via faker
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,9 @@
+black ; python_version == '3.7.*'
 docutils
 factory_boy
 faker
 flake8
+flake8-bugbear
 isort
 multilint
 numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,15 @@
 [flake8]
-max-line-length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E203,E501,W503
 
 [isort]
-multi_line_output = 5
+include_trailing_comma = True
+force_grid_wrap = 0
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -4,51 +4,46 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('pytest_randomly.py')
+version = get_version("pytest_randomly.py")
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
-    history = history_file.read().replace('.. :changelog:', '')
+with open("HISTORY.rst", "r") as history_file:
+    history = history_file.read().replace(".. :changelog:", "")
 
 setup(
-    name='pytest-randomly',
+    name="pytest-randomly",
     version=version,
-    description="Pytest plugin to randomly order tests and control "
-                "random.seed.",
-    long_description=readme + '\n\n' + history,
+    description="Pytest plugin to randomly order tests and control " "random.seed.",
+    long_description=readme + "\n\n" + history,
     author="Adam Johnson",
-    author_email='me@adamj.eu',
-    url='https://github.com/pytest-dev/pytest-randomly',
-    py_modules=['pytest_randomly'],
+    author_email="me@adamj.eu",
+    url="https://github.com/pytest-dev/pytest-randomly",
+    py_modules=["pytest_randomly"],
     include_package_data=True,
-    install_requires=[
-        'pytest',
-    ],
-    python_requires='>=3.5',
+    install_requires=["pytest"],
+    python_requires=">=3.5",
     license="BSD",
     zip_safe=False,
-    keywords='pytest, random, randomize, randomise, randomly',
-    entry_points={
-        'pytest11': ['randomly = pytest_randomly'],
-    },
+    keywords="pytest, random, randomize, randomise, randomly",
+    entry_points={"pytest11": ["randomly = pytest_randomly"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Pytest',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: Pytest",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_pytest_randomly.py
+++ b/test_pytest_randomly.py
@@ -1,13 +1,12 @@
 import pytest
 
-pytest_plugins = ['pytester']
+pytest_plugins = ["pytester"]
 
 
 @pytest.fixture
 def ourtestdir(testdir):
-    testdir.tmpdir.join('pytest.ini').write(
-        '[pytest]\n'
-        'console_output_style = classic'
+    testdir.tmpdir.join("pytest.ini").write(
+        "[pytest]\n" "console_output_style = classic"
     )
 
     # Change from default running pytest in-process to running in a subprocess
@@ -33,17 +32,13 @@ def simpletestdir(ourtestdir):
 
 def test_it_reports_a_header_when_not_set(simpletestdir):
     out = simpletestdir.runpytest()
-    assert len([
-        x for x in out.outlines if x.startswith('Using --randomly-seed=')
-    ]) == 1
+    assert len([x for x in out.outlines if x.startswith("Using --randomly-seed=")]) == 1
 
 
 def test_it_reports_a_header_when_set(simpletestdir):
-    out = simpletestdir.runpytest('--randomly-seed=10')
-    lines = [x for x in out.outlines if x.startswith('Using --randomly-seed=')]
-    assert lines == [
-        'Using --randomly-seed=10'
-    ]
+    out = simpletestdir.runpytest("--randomly-seed=10")
+    lines = [x for x in out.outlines if x.startswith("Using --randomly-seed=")]
+    assert lines == ["Using --randomly-seed=10"]
 
 
 def test_it_reuses_the_same_random_seed_per_test(ourtestdir):
@@ -66,7 +61,7 @@ def test_it_reuses_the_same_random_seed_per_test(ourtestdir):
                 assert test_b.num == test_a.num
         """
     )
-    out = ourtestdir.runpytest('--randomly-dont-reorganize')
+    out = ourtestdir.runpytest("--randomly-dont-reorganize")
     out.assert_outcomes(passed=2, failed=0)
 
 
@@ -79,9 +74,11 @@ def test_using_last_seed(ourtestdir):
     )
     out = ourtestdir.runpytest()
     out.assert_outcomes(passed=1, failed=0)
-    seed_line = [x for x in out.stdout.lines if x.startswith('Using --randomly-seed=')][0]
+    seed_line = [x for x in out.stdout.lines if x.startswith("Using --randomly-seed=")][
+        0
+    ]
 
-    out = ourtestdir.runpytest('--randomly-seed=last')
+    out = ourtestdir.runpytest("--randomly-seed=last")
     out.assert_outcomes(passed=1, failed=0)
     out.stdout.fnmatch_lines([seed_line])
 
@@ -93,13 +90,13 @@ def test_using_last_explicit_seed(ourtestdir):
             pass
         """
     )
-    out = ourtestdir.runpytest('--randomly-seed=33')
+    out = ourtestdir.runpytest("--randomly-seed=33")
     out.assert_outcomes(passed=1, failed=0)
-    out.stdout.fnmatch_lines(['Using --randomly-seed=33'])
+    out.stdout.fnmatch_lines(["Using --randomly-seed=33"])
 
-    out = ourtestdir.runpytest('--randomly-seed=last')
+    out = ourtestdir.runpytest("--randomly-seed=last")
     out.assert_outcomes(passed=1, failed=0)
-    out.stdout.fnmatch_lines(['Using --randomly-seed=33'])
+    out.stdout.fnmatch_lines(["Using --randomly-seed=33"])
 
 
 def test_passing_nonsense_for_randomly_seed(ourtestdir):
@@ -109,11 +106,16 @@ def test_passing_nonsense_for_randomly_seed(ourtestdir):
             pass
         """
     )
-    out = ourtestdir.runpytest('--randomly-seed=invalidvalue')
+    out = ourtestdir.runpytest("--randomly-seed=invalidvalue")
     assert out.ret != 0
-    out.stderr.fnmatch_lines([
-        "pytest.py: error: argument --randomly-seed: 'invalidvalue' is not an integer or the string 'last'"
-    ])
+    out.stderr.fnmatch_lines(
+        [
+            (
+                "pytest.py: error: argument --randomly-seed: 'invalidvalue' "
+                + "is not an integer or the string 'last'"
+            )
+        ]
+    )
 
 
 def test_it_resets_the_random_seed_at_the_start_of_test_classes(ourtestdir):
@@ -205,7 +207,7 @@ def test_the_same_random_seed_per_test_can_be_turned_off(ourtestdir):
         """
     )
     out = ourtestdir.runpytest(
-        '--randomly-dont-reset-seed', '--randomly-dont-reorganize',
+        "--randomly-dont-reset-seed", "--randomly-dont-reorganize"
     )
     out.assert_outcomes(passed=2, failed=0)
 
@@ -215,22 +217,17 @@ def test_files_reordered(ourtestdir):
         def test_it():
             pass
     """
-    ourtestdir.makepyfile(
-        test_a=code,
-        test_b=code,
-        test_c=code,
-        test_d=code,
-    )
-    args = ['-v', '--randomly-seed=15']
+    ourtestdir.makepyfile(test_a=code, test_b=code, test_c=code, test_d=code)
+    args = ["-v", "--randomly-seed=15"]
 
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_d.py::test_it PASSED',
-        'test_c.py::test_it PASSED',
-        'test_a.py::test_it PASSED',
-        'test_b.py::test_it PASSED',
+        "test_d.py::test_it PASSED",
+        "test_c.py::test_it PASSED",
+        "test_a.py::test_it PASSED",
+        "test_b.py::test_it PASSED",
     ]
 
 
@@ -239,23 +236,18 @@ def test_files_reordered_when_seed_not_reset(ourtestdir):
         def test_it():
             pass
     """
-    ourtestdir.makepyfile(
-        test_a=code,
-        test_b=code,
-        test_c=code,
-        test_d=code,
-    )
-    args = ['-v', '--randomly-seed=15']
+    ourtestdir.makepyfile(test_a=code, test_b=code, test_c=code, test_d=code)
+    args = ["-v", "--randomly-seed=15"]
 
-    args.append('--randomly-dont-reset-seed')
+    args.append("--randomly-dont-reset-seed")
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_d.py::test_it PASSED',
-        'test_c.py::test_it PASSED',
-        'test_a.py::test_it PASSED',
-        'test_b.py::test_it PASSED',
+        "test_d.py::test_it PASSED",
+        "test_c.py::test_it PASSED",
+        "test_a.py::test_it PASSED",
+        "test_b.py::test_it PASSED",
     ]
 
 
@@ -285,16 +277,16 @@ def test_classes_reordered(ourtestdir):
                 pass
         """
     )
-    args = ['-v', '--randomly-seed=15']
+    args = ["-v", "--randomly-seed=15"]
 
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_one.py::D::test_d PASSED',
-        'test_one.py::C::test_c PASSED',
-        'test_one.py::A::test_a PASSED',
-        'test_one.py::B::test_b PASSED',
+        "test_one.py::D::test_d PASSED",
+        "test_one.py::C::test_c PASSED",
+        "test_one.py::A::test_a PASSED",
+        "test_one.py::B::test_b PASSED",
     ]
 
 
@@ -317,16 +309,16 @@ def test_class_test_methods_reordered(ourtestdir):
                 pass
         """
     )
-    args = ['-v', '--randomly-seed=15']
+    args = ["-v", "--randomly-seed=15"]
 
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_one.py::T::test_d PASSED',
-        'test_one.py::T::test_c PASSED',
-        'test_one.py::T::test_a PASSED',
-        'test_one.py::T::test_b PASSED',
+        "test_one.py::T::test_d PASSED",
+        "test_one.py::T::test_c PASSED",
+        "test_one.py::T::test_a PASSED",
+        "test_one.py::T::test_b PASSED",
     ]
 
 
@@ -346,16 +338,16 @@ def test_test_functions_reordered(ourtestdir):
             pass
         """
     )
-    args = ['-v', '--randomly-seed=15']
+    args = ["-v", "--randomly-seed=15"]
 
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_one.py::test_d PASSED',
-        'test_one.py::test_c PASSED',
-        'test_one.py::test_a PASSED',
-        'test_one.py::test_b PASSED',
+        "test_one.py::test_d PASSED",
+        "test_one.py::test_c PASSED",
+        "test_one.py::test_a PASSED",
+        "test_one.py::test_b PASSED",
     ]
 
 
@@ -380,16 +372,16 @@ def test_test_functions_reordered_when_randomness_in_module(ourtestdir):
             pass
         """
     )
-    args = ['-v', '--randomly-seed=15']
+    args = ["-v", "--randomly-seed=15"]
 
     out = ourtestdir.runpytest(*args)
 
     out.assert_outcomes(passed=4, failed=0)
     assert out.outlines[8:12] == [
-        'test_one.py::test_d PASSED',
-        'test_one.py::test_c PASSED',
-        'test_one.py::test_a PASSED',
-        'test_one.py::test_b PASSED',
+        "test_one.py::test_d PASSED",
+        "test_one.py::test_c PASSED",
+        "test_one.py::test_a PASSED",
+        "test_one.py::test_b PASSED",
     ]
 
 
@@ -411,13 +403,13 @@ def test_doctests_reordered(ourtestdir):
             return 9002
         """
     )
-    args = ['-v', '--doctest-modules', '--randomly-seed=5']
+    args = ["-v", "--doctest-modules", "--randomly-seed=5"]
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)
     assert out.outlines[8:10] == [
-        'test_one.py::test_one.bar PASSED',
-        'test_one.py::test_one.foo PASSED',
+        "test_one.py::test_one.bar PASSED",
+        "test_one.py::test_one.foo PASSED",
     ]
 
 
@@ -459,28 +451,32 @@ def test_it_works_with_the_simplest_test_items(ourtestdir):
             )
         """
     )
-    args = ['-v']
+    args = ["-v"]
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)
 
 
 def test_doctests_in_txt_files_reordered(ourtestdir):
-    ourtestdir.tmpdir.join('test.txt').write('''\
+    ourtestdir.tmpdir.join("test.txt").write(
+        """\
         >>> 2 + 2
         4
-        ''')
-    ourtestdir.tmpdir.join('test2.txt').write('''\
+        """
+    )
+    ourtestdir.tmpdir.join("test2.txt").write(
+        """\
         >>> 2 - 2
         0
-        ''')
-    args = ['-v', '--randomly-seed=1']
+        """
+    )
+    args = ["-v", "--randomly-seed=1"]
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)
     assert out.outlines[8:10] == [
-        'test2.txt::test2.txt PASSED',
-        'test.txt::test.txt PASSED',
+        "test2.txt::test2.txt PASSED",
+        "test.txt::test.txt PASSED",
     ]
 
 
@@ -532,14 +528,14 @@ def test_fixtures_dont_interfere_with_tests_getting_same_random_state(ourtestdir
             assert random.getstate() == state_at_seed_two
         """
     )
-    args = ['--randomly-seed=2']
+    args = ["--randomly-seed=2"]
 
     out = ourtestdir.runpytest(*args)
     out.assert_outcomes(passed=2)
 
-    out = ourtestdir.runpytest('-m', 'one', *args)
+    out = ourtestdir.runpytest("-m", "one", *args)
     out.assert_outcomes(passed=1)
-    out = ourtestdir.runpytest('-m', 'two', *args)
+    out = ourtestdir.runpytest("-m", "two", *args)
     out.assert_outcomes(passed=1)
 
 
@@ -564,7 +560,7 @@ def test_factory_boy(ourtestdir):
         """
     )
 
-    out = ourtestdir.runpytest('--randomly-seed=1')
+    out = ourtestdir.runpytest("--randomly-seed=1")
     out.assert_outcomes(passed=2)
 
 
@@ -583,7 +579,7 @@ def test_faker(ourtestdir):
         """
     )
 
-    out = ourtestdir.runpytest('--randomly-seed=1')
+    out = ourtestdir.runpytest("--randomly-seed=1")
     out.assert_outcomes(passed=2)
 
 
@@ -600,7 +596,7 @@ def test_numpy(ourtestdir):
         """
     )
 
-    out = ourtestdir.runpytest('--randomly-seed=1')
+    out = ourtestdir.runpytest("--randomly-seed=1")
     out.assert_outcomes(passed=2)
 
 


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.5
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code
* Add README badge