### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Install from pip with:
 
     pip install pytest-randomly
 
-Python 3.5-3.8 supported.
+Python 3.5 to 3.8 supported.
 
 Pytest will automatically find the plugin and use it when you run ``pytest``.
 The output will start with an extra line that tells you the random seed that is


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.