### PR TITLE
Add faker and faker_seed fixtures support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 -------
 
+* Provide a ``faker_seed`` fixture to set the seed for tests using faker's
+  pytest fixtures (as per its
+  `docs <https://faker.readthedocs.io/en/master/pytest-fixtures.html#seeding-configuration>`__).
+
+  Thanks to Romain Létendart for the change in `PR #261
+  <https://github.com/pytest-dev/pytest-randomly/pull/261>`__.
+
 3.3.1 (2020-04-15)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,10 @@ All of these features are on by default but can be disabled with flags.
   allows for repeatable use of its random 'fuzzy' features.
 * If `faker <https://pypi.python.org/pypi/faker>`_ is installed, its random
   state is reset at the start of every test. This is also for repeatable fuzzy
-  data in tests - factory boy uses faker for lots of data.
+  data in tests - factory boy uses faker for lots of data. This is also done
+  if you're using the ``faker`` pytest fixture, by defining the ``faker_seed``
+  fixture
+  (`docs <https://faker.readthedocs.io/en/master/pytest-fixtures.html#seeding-configuration>`__).
 * If `numpy <http://www.numpy.org/>`_ is installed, its random state is reset
   at the start of every test.
 * If additional random generators are used, they can be registered under the
@@ -57,11 +60,11 @@ tests themselves, as well as giving a little more coverage to your system.
 By randomly ordering the tests, the risk of surprising inter-test dependencies
 is reduced - a technique used in many places, for example Google's C++ test
 runner `googletest
-<https://code.google.com/p/googletest/wiki/V1_5_AdvancedGuide#Shuffling_the_Tests>`_. 
-Research suggests that "dependent tests do exist in practice" and a random 
-order of test executions can effectively detect such dependencies [1]_. 
-Alternatively, a reverse order of test executions, as provided by `pytest-reverse 
-<https://github.com/adamchainz/pytest-reverse>`__, may find less dependent 
+<https://code.google.com/p/googletest/wiki/V1_5_AdvancedGuide#Shuffling_the_Tests>`_.
+Research suggests that "dependent tests do exist in practice" and a random
+order of test executions can effectively detect such dependencies [1]_.
+Alternatively, a reverse order of test executions, as provided by `pytest-reverse
+<https://github.com/adamchainz/pytest-reverse>`__, may find less dependent
 tests but can achieve a better benefit/cost ratio.
 
 By resetting the random seed to a repeatable number for each test, tests can

--- a/src/pytest_randomly.py
+++ b/src/pytest_randomly.py
@@ -3,8 +3,7 @@ import random
 import sys
 import time
 
-from pytest import Collector
-from pytest import fixture
+from pytest import Collector, fixture
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points

--- a/src/pytest_randomly.py
+++ b/src/pytest_randomly.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 from pytest import Collector
+from pytest import fixture
 
 if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
@@ -239,3 +240,9 @@ def reduce_list_of_lists(lists):
     for list_ in lists:
         new_list.extend(list_)
     return new_list
+
+
+if have_faker:
+    @fixture(name='faker_seed', autouse=True)
+    def faker_seed_fixture(pytestconfig):
+        return pytestconfig.getoption("randomly_seed")

--- a/src/pytest_randomly.py
+++ b/src/pytest_randomly.py
@@ -243,6 +243,7 @@ def reduce_list_of_lists(lists):
 
 
 if have_faker:
-    @fixture(name='faker_seed', autouse=True)
-    def faker_seed_fixture(pytestconfig):
+
+    @fixture(autouse=True)
+    def faker_seed(pytestconfig):
         return pytestconfig.getoption("randomly_seed")

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -593,6 +593,21 @@ def test_faker(ourtestdir):
     out.assert_outcomes(passed=2)
 
 
+def test_faker_fixture(ourtestdir):
+    ourtestdir.makepyfile(
+        test_one="""
+        def test_one(faker):
+            assert faker.name() == 'Ryan Gallagher'
+
+        def test_two(faker):
+            assert faker.name() == 'Ryan Gallagher'
+        """
+    )
+
+    out = ourtestdir.runpytest("--randomly-seed=1")
+    out.assert_outcomes(passed=2)
+
+
 def test_numpy(ourtestdir):
     ourtestdir.makepyfile(
         test_one="""


### PR DESCRIPTION
Faker offers both `faker` and `faker_seed` fixtures.
The problem is that using only the `faker` fixture simply ignores `pytest-randomly`'s seed.
The [documented way](https://faker.readthedocs.io/en/master/pytest-fixtures.html#seeding-configuration) of seeding the `faker` fixture mentions using `faker_seed`.
This PR is a proposal to make `pytest-randomly` provide its seed to `faker` via `faker_seed`.