### PR TITLE
Use importlib-metadata more elegantly

### DIFF
--- a/src/pytest_randomly.py
+++ b/src/pytest_randomly.py
@@ -146,8 +146,7 @@ def _reseed(config, offset=0):
 
     if entrypoint_reseeds is None:
         entrypoint_reseeds = [
-            e.load()
-            for e in entry_points().select(group="pytest_randomly.random_seeder")
+            e.load() for e in entry_points(group="pytest_randomly.random_seeder")
         ]
     for reseed in entrypoint_reseeds:
         reseed(seed)

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -675,10 +674,7 @@ def test_entrypoint_injection(testdir, monkeypatch):
 
     entry_points = []
 
-    def fake_entry_points():
-        return SimpleNamespace(select=fake_select)
-
-    def fake_select(*, group):
+    def fake_entry_points(*, group):
         return entry_points
 
     monkeypatch.setattr(pytest_randomly, "entry_points", fake_entry_points)


### PR DESCRIPTION
[docs](https://importlib-metadata.readthedocs.io/en/latest/using.html#entry-points) say:

> Equivalently, since entry_points passes keyword arguments through to select:
> `>>> scripts = entry_points(group='console_scripts')`

So do that.