### PR TITLE
Fix crash when pytest’s cacheprovdier is disabled

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+* Fix crash when pytest’s cacheprovider is disabled.
+
+  Thanks to Mandeep Sandhu for the report in `Issue #408
+  <https://github.com/pytest-dev/pytest-randomly/issues/408>`__.
+
 * Improve group name in ``pytest --help``.
 
 3.10.1 (2021-08-13)

--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,8 @@ Or more conveniently, use the special value ``last``:
 
     pytest --randomly-seed=last
 
+(This only works if pytest’s cacheprovider plugin has not been disabled.)
+
 Since the ordering is by module, then by class, you can debug inter-test
 pollution failures by narrowing down which tests are being run to find the bad
 interaction by rerunning just the module/class:

--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -103,6 +103,9 @@ def pytest_configure(config: Config) -> None:
 
     seed_value = config.getoption("randomly_seed")
     if seed_value == "last":
+        assert hasattr(
+            config, "cache"
+        ), "The cacheprovider plugin is required to use 'last'"
         assert config.cache is not None
         seed = config.cache.get("randomly_seed", default_seed)
     elif seed_value == "default":
@@ -113,8 +116,9 @@ def pytest_configure(config: Config) -> None:
             seed = default_seed
     else:
         seed = seed_value
-    assert config.cache is not None
-    config.cache.set("randomly_seed", seed)
+    if hasattr(config, "cache"):
+        assert config.cache is not None
+        config.cache.set("randomly_seed", seed)
     config.option.randomly_seed = seed
 
 

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -76,6 +76,17 @@ def test_it_reuses_the_same_random_seed_per_test(ourtestdir):
     out.assert_outcomes(passed=2, failed=0)
 
 
+def test_without_cacheprovider(ourtestdir):
+    ourtestdir.makepyfile(
+        test_one="""
+        def test_a():
+            pass
+        """
+    )
+    out = ourtestdir.runpytest("-p", "no:cacheprovider")
+    out.assert_outcomes(passed=1, failed=0)
+
+
 def test_using_last_seed(ourtestdir):
     ourtestdir.makepyfile(
         test_one="""


### PR DESCRIPTION
Fixes #408.