### PR TITLE
Mark use of hashlib.md5() as not for security

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+* Work on FIPS Python 3.9+, by declaring use of ``hashlib.md5()`` as not used for security.
+
+  Thanks to dantebben for the report in `Issue #414 <https://github.com/pytest-dev/pytest-randomly/issues/414>`__.
+
 3.10.2 (2021-11-10)
 -------------------
 

--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -11,6 +11,8 @@ from _pytest.config.argparsing import Parser
 from _pytest.nodes import Item
 from pytest import Collector, fixture, hookimpl
 
+from pytest_randomly.compat import md5
+
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
 else:
@@ -274,7 +276,7 @@ def reduce_list_of_lists(lists: List[List[T]]) -> List[T]:
 
 
 def _md5(string: str) -> bytes:
-    hasher = hashlib.md5()
+    hasher = md5()
     hasher.update(string.encode())
     return hasher.digest()
 

--- a/src/pytest_randomly/compat.py
+++ b/src/pytest_randomly/compat.py
@@ -1,0 +1,8 @@
+import hashlib
+import sys
+from functools import partial
+
+if sys.version_info >= (3, 9):
+    md5 = partial(hashlib.md5, usedforsecurity=False)
+else:
+    md5 = hashlib.md5


### PR DESCRIPTION
Fixes #414.