### PR TITLE
Fix requirements/compile.py when PIP_REQUIRE_VIRTUALENV isn't set

### DIFF
--- a/requirements/compile.py
+++ b/requirements/compile.py
@@ -7,7 +7,7 @@ from pathlib import Path
 if __name__ == "__main__":
     os.chdir(Path(__file__).parent)
     os.environ["CUSTOM_COMPILE_COMMAND"] = "requirements/compile.py"
-    os.environ.pop("PIP_REQUIRE_VIRTUALENV")
+    os.environ.pop("PIP_REQUIRE_VIRTUALENV", None)
     common_args = [
         "-m",
         "piptools",


### PR DESCRIPTION
Copy of https://github.com/adamchainz/django-browser-reload/pull/29