### PR TITLE
Add ability to selectively not shuffle tests by using markers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,15 @@ You can disable behaviours you don't like with the following flags:
   the start of every test
 * ``--randomly-dont-reorganize`` - turn off the shuffling of the order of tests
 
+Or you can selectively disable the shuffling of the test order with the
+``randomly_dont_reorganize`` marker:
+
+* ``pytestmark = pytest.mark.randomly_dont_reorganize`` - disable shuffling for
+  all tests in a module
+* ``@pytest.mark.randomly_dont_reorganize`` - disable shuffling for a class or function
+Note: if using the marker on individual tests, all functions inside a module must be marked,
+due to how the plugin shuffles test execution order
+
 The plugin appears to Pytest with the name 'randomly'. To disable it
 altogether, you can use the ``-p`` argument, for example:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ addopts = """\
     --strict-config
     --strict-markers
     """
+markers = [
+    "randomly_dont_reorganize: Do not shuffle marked class or module",
+]
 
 [tool.mypy]
 mypy_path = "src/"

--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -232,7 +232,9 @@ def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
         module_items = list(group)
 
         for item in module_items:
-            marker_finder = getattr(item, "get_closest_marker", getattr(item, "get_marker", None))
+            marker_finder = getattr(
+                item, "get_closest_marker", getattr(item, "get_marker", None)
+            )
             if not marker_finder("randomly_dont_reorganize"):
                 module_items = _shuffle_by_class(module_items, seed)
                 break
@@ -267,7 +269,9 @@ def _shuffle_by_class(items: list[Item], seed: int) -> list[Item]:
         klass_items = list(group)
 
         for item in klass_items:
-            marker_finder = getattr(item, "get_closest_marker", getattr(item, "get_marker", None))
+            marker_finder = getattr(
+                item, "get_closest_marker", getattr(item, "get_marker", None)
+            )
             if not marker_finder("randomly_dont_reorganize"):
                 klass_items.sort(key=_item_key)
                 break

--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -232,10 +232,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
         module_items = list(group)
 
         for item in module_items:
-            marker_finder = getattr(
-                item, "get_closest_marker", getattr(item, "get_marker", None)
-            )
-            if not marker_finder("randomly_dont_reorganize"):
+            if not item.get_closest_marker("randomly_dont_reorganize"):
                 module_items = _shuffle_by_class(module_items, seed)
                 break
 
@@ -269,10 +266,7 @@ def _shuffle_by_class(items: list[Item], seed: int) -> list[Item]:
         klass_items = list(group)
 
         for item in klass_items:
-            marker_finder = getattr(
-                item, "get_closest_marker", getattr(item, "get_marker", None)
-            )
-            if not marker_finder("randomly_dont_reorganize"):
+            if not item.get_closest_marker("randomly_dont_reorganize"):
                 klass_items.sort(key=_item_key)
                 break
 

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -594,16 +594,18 @@ def test_test_files_reordered_unless_marked(ourtester):
         def test_3():
             pass
     """
-    ourtester.makepyfile(test_a=code,
-                         test_b=code,
-                         test_c=f"""
+    ourtester.makepyfile(
+        test_a=code,
+        test_b=code,
+        test_c=f"""
         import pytest
 
         pytestmark = pytest.mark.randomly_dont_reorganize
 
         {code}
         """,
-                         test_d=code)
+        test_d=code,
+    )
     args = ["-v", "--randomly-seed=15"]
 
     out = ourtester.runpytest(*args)


### PR DESCRIPTION
A new marker `randomly_dont_reorganize` allows for disabling shuffling for select classes or modules.
Note: Due to how the plugin works, disabling shuffling only works for entire classes or modules, not for individual functions (including parametrized tests)

Edit: Resolves #319 