### PR TITLE
Set faker_seed fixture to session scope

### DIFF
--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -296,7 +296,7 @@ def _md5(string: str) -> bytes:
 
 if have_faker:  # pragma: no branch
 
-    @fixture(autouse=True)
+    @fixture(autouse=True, scope="session")
     def faker_seed(pytestconfig: Config) -> int:
         result: int = pytestconfig.getoption("randomly_seed")
         return result

--- a/tests/requirements/py310.txt
+++ b/tests/requirements/py310.txt
@@ -84,9 +84,9 @@ factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
     # via -r requirements.in
-faker==30.8.1 \
-    --hash=sha256:4f7f133560b9d4d2a915581f4ba86f9a6a83421b89e911f36c4c96cff58135a5 \
-    --hash=sha256:93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
+faker==32.1.0 \
+    --hash=sha256:aac536ba04e6b7beb2332c67df78485fc29c1880ff723beac6d1efd45e2f10f5 \
+    --hash=sha256:c77522577863c264bdc9dad3a2a750ad3f7ee43ff8185072e482992288898814
     # via
     #   -r requirements.in
     #   factory-boy

--- a/tests/requirements/py311.txt
+++ b/tests/requirements/py311.txt
@@ -80,9 +80,9 @@ factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
     # via -r requirements.in
-faker==30.8.1 \
-    --hash=sha256:4f7f133560b9d4d2a915581f4ba86f9a6a83421b89e911f36c4c96cff58135a5 \
-    --hash=sha256:93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
+faker==32.1.0 \
+    --hash=sha256:aac536ba04e6b7beb2332c67df78485fc29c1880ff723beac6d1efd45e2f10f5 \
+    --hash=sha256:c77522577863c264bdc9dad3a2a750ad3f7ee43ff8185072e482992288898814
     # via
     #   -r requirements.in
     #   factory-boy

--- a/tests/requirements/py312.txt
+++ b/tests/requirements/py312.txt
@@ -80,9 +80,9 @@ factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
     # via -r requirements.in
-faker==30.8.1 \
-    --hash=sha256:4f7f133560b9d4d2a915581f4ba86f9a6a83421b89e911f36c4c96cff58135a5 \
-    --hash=sha256:93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
+faker==32.1.0 \
+    --hash=sha256:aac536ba04e6b7beb2332c67df78485fc29c1880ff723beac6d1efd45e2f10f5 \
+    --hash=sha256:c77522577863c264bdc9dad3a2a750ad3f7ee43ff8185072e482992288898814
     # via
     #   -r requirements.in
     #   factory-boy

--- a/tests/requirements/py313.txt
+++ b/tests/requirements/py313.txt
@@ -80,9 +80,9 @@ factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
     # via -r requirements.in
-faker==30.8.1 \
-    --hash=sha256:4f7f133560b9d4d2a915581f4ba86f9a6a83421b89e911f36c4c96cff58135a5 \
-    --hash=sha256:93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
+faker==32.1.0 \
+    --hash=sha256:aac536ba04e6b7beb2332c67df78485fc29c1880ff723beac6d1efd45e2f10f5 \
+    --hash=sha256:c77522577863c264bdc9dad3a2a750ad3f7ee43ff8185072e482992288898814
     # via
     #   -r requirements.in
     #   factory-boy

--- a/tests/requirements/py39.txt
+++ b/tests/requirements/py39.txt
@@ -84,9 +84,9 @@ factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
     # via -r requirements.in
-faker==30.8.1 \
-    --hash=sha256:4f7f133560b9d4d2a915581f4ba86f9a6a83421b89e911f36c4c96cff58135a5 \
-    --hash=sha256:93e8b70813f76d05d98951154681180cb795cfbcff3eced7680d963bcc0da2a9
+faker==32.1.0 \
+    --hash=sha256:aac536ba04e6b7beb2332c67df78485fc29c1880ff723beac6d1efd45e2f10f5 \
+    --hash=sha256:c77522577863c264bdc9dad3a2a750ad3f7ee43ff8185072e482992288898814
     # via
     #   -r requirements.in
     #   factory-boy

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -663,7 +663,7 @@ def test_faker_fixture(ourtester):
             assert faker.name() == 'Ryan Gallagher'
 
         def test_two(faker):
-            assert faker.name() == 'Ryan Gallagher'
+            assert faker.name() == 'Jon Cole'
         """
     )
 


### PR DESCRIPTION
Faker has changed its main fixture to be session scoped in v32 and uses `faker_seed`: 

- https://github.com/joke2k/faker/pull/2117

So the fixture from `pytest-randomly` needs to match the same scope

Fix #656