### PR TITLE
Reset Polyfactory's random state on each test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Reset `Polyfactory <https://polyfactory.litestar.dev/>`__’s default random state at the start of every test, if it is installed.
+
+  Thanks to davidszotten for the request in `Issue #720 <https://github.com/pytest-dev/pytest-randomly/issues/720>`__.
+
 4.1.0 (2026-04-20)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,11 @@ All of these features are on by default but can be disabled with flags.
 
     Only its `legacy random state <https://numpy.org/doc/stable/reference/random/legacy.html>`__ is affected.
 
+  * `Polyfactory <https://polyfactory.litestar.dev/>`__
+
+    Only the default random generator is affected. Factories that have called
+    ``seed_random()`` with their own seed are unaffected.
+
 * If additional random generators are used, they can be registered under the
   ``pytest_randomly.random_seeder``
   `entry point <https://packaging.python.org/specifications/entry-points/>`_ and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
   "faker",
   "model-bakery>=1.13",
   "numpy",
+  "polyfactory",
   "pytest>=9",
   "pytest-xdist",
 ]

--- a/src/pytest_randomly/__init__.py
+++ b/src/pytest_randomly/__init__.py
@@ -54,6 +54,14 @@ try:
 except ImportError:  # pragma: no cover
     have_numpy = False
 
+# polyfactory
+try:
+    from polyfactory.constants import DEFAULT_RANDOM as polyfactory_random
+
+    have_polyfactory = True
+except ImportError:  # pragma: no cover
+    have_polyfactory = False
+
 
 def make_seed() -> int:
     return random.Random().getrandbits(32)
@@ -156,6 +164,9 @@ def _reseed(config: Config, offset: int = 0) -> int:
 
     if have_numpy:  # pragma: no branch
         np_random.seed(seed % 2**32)
+
+    if have_polyfactory:  # pragma: no branch
+        polyfactory_random.setstate(random_state)
 
     if entrypoint_reseeds is None:
         eps = entry_points(group="pytest_randomly.random_seeder")

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -699,17 +699,24 @@ def test_numpy_doesnt_crash_with_large_seed(ourtester):
 def test_polyfactory(ourtester):
     """
     Check that Polyfactory's default random generator is reset between tests.
+
+    Uses a Union-typed field so the assertion depends on
+    DEFAULT_RANDOM.choice() picking which type to generate. A plain ``int``
+    field wouldn't do: Polyfactory generates those via its Faker instance,
+    whose random generator pytest-randomly already reseeds separately, so
+    such a test would pass even without resetting DEFAULT_RANDOM.
     """
     ourtester.makepyfile(
         test_one="""
         from dataclasses import dataclass
+        from typing import Union
 
         from polyfactory.factories import DataclassFactory
 
 
         @dataclass
         class Foo:
-            x: int
+            x: Union[int, str, float, bytes]
 
 
         class FooFactory(DataclassFactory[Foo]):
@@ -717,11 +724,15 @@ def test_polyfactory(ourtester):
 
 
         def test_a():
-            assert FooFactory.build().x == 2927
+            value = FooFactory.build().x
+            assert isinstance(value, str)
+            assert value == 'jKdWckZoDYuPmqHSsjBh'
 
 
         def test_b():
-            assert FooFactory.build().x == 1908
+            value = FooFactory.build().x
+            assert isinstance(value, int)
+            assert value == 1908
         """
     )
 

--- a/tests/test_pytest_randomly.py
+++ b/tests/test_pytest_randomly.py
@@ -696,6 +696,39 @@ def test_numpy_doesnt_crash_with_large_seed(ourtester):
     out.assert_outcomes(passed=1)
 
 
+def test_polyfactory(ourtester):
+    """
+    Check that Polyfactory's default random generator is reset between tests.
+    """
+    ourtester.makepyfile(
+        test_one="""
+        from dataclasses import dataclass
+
+        from polyfactory.factories import DataclassFactory
+
+
+        @dataclass
+        class Foo:
+            x: int
+
+
+        class FooFactory(DataclassFactory[Foo]):
+            __model__ = Foo
+
+
+        def test_a():
+            assert FooFactory.build().x == 2927
+
+
+        def test_b():
+            assert FooFactory.build().x == 1908
+        """
+    )
+
+    out = ourtester.runpytest("--randomly-seed=1")
+    out.assert_outcomes(passed=2)
+
+
 def test_failing_import(testdir):
     """Test with pytest raising CollectError or ImportError.
 


### PR DESCRIPTION
Polyfactory keeps its own default `random.Random()` instance (`polyfactory.constants.DEFAULT_RANDOM`) separate from Faker's, so it wasn't being reseeded along with the other libraries pytest-randomly already supports.

This adds Polyfactory to the same try/except reseed pattern used for factory_boy, Faker, Model Bakery, and NumPy, so factories using the default random generator get deterministic, per-test values under `--randomly-seed`. Factories that call `seed_random()` themselves are unaffected, same as before.

Closes #720.